### PR TITLE
[COM-1136] Export breakpoints from DSM and update units/rems exported to be fixed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yaml]
+trim_trailing_whitespace = none
+insert_final_newline = none
+indent_size = none
+max_line_length = 1000
+
+[*.yml]
+trim_trailing_whitespace = none
+insert_final_newline = none
+indent_size = none
+max_line_length = 1000
+
+[*.ts*]
+quote_type = single
+max_line_length = 120
+
+[*.js*]
+quote_type = single

--- a/src/breakpoints.ts
+++ b/src/breakpoints.ts
@@ -1,0 +1,23 @@
+import { PAGE_IDS, THEME_PREFIXES } from './constants';
+import { Page } from './page';
+import { convertPxToRem } from './utils';
+
+export class Breakpoints extends Page {
+  constructor() {
+    super(PAGE_IDS.BREAKPOINTS);
+  }
+
+  get = () => {
+    this.traversePage((node: SceneNode) => {
+      if (this.nodeStartsWithPrefix(node.name, THEME_PREFIXES.BREAKPOINTS)) {
+        const breakpointToken = node.name.replace(THEME_PREFIXES.BREAKPOINTS, '');
+        this.data[breakpointToken] = convertPxToRem(node.width);
+      }
+    });
+    // We need to hardcode base and xxl tokens to avoid issues with default chakra breakpoints
+    this.data['base'] = '0rem';
+    this.data['xxl'] = this.data['2xl'];
+
+    return this.data;
+  };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export const THEME_PREFIXES = {
+  BREAKPOINTS: 'breakpoints-',
   COLORS: 'color-',
   SPACINGS: 'spacer-',
   RADIUS: 'radii-',
@@ -17,6 +18,7 @@ export const THEME_PREFIXES = {
 };
 
 export const PAGE_IDS = {
+  BREAKPOINTS: '809:9977',
   COLORS: '806:9205',
   ELEVATIONS: '806:9207',
   SPACINGS: '806:9208',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,3 +1,4 @@
+import { Breakpoints } from './breakpoints';
 import { Colors } from './colors';
 import { Elevations } from './elevations';
 import { Radius } from './radius';
@@ -6,6 +7,7 @@ import { Texts } from './texts';
 import { TextsPairings } from './textsPairings';
 
 export class Theme {
+  breakpoints: {};
   colors: {};
   spacings: {};
   radius: {};
@@ -14,6 +16,7 @@ export class Theme {
   textsPairings: { parts: string[]; variants: {} };
 
   constructor() {
+    this.breakpoints = new Breakpoints().get();
     this.colors = new Colors().get();
     this.spacings = new Spacings().get();
     this.radius = new Radius().get();
@@ -23,6 +26,7 @@ export class Theme {
   }
 
   get = () => ({
+    breakpoints: this.breakpoints,
     colors: this.colors,
     space: this.spacings,
     radii: this.radius,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
 const rootFontSize = 16;
-export const convertPxToRem = (pixel: number) => `${pixel / rootFontSize}rem`;
+export const convertPxToRem = (pixel: number, fixedDigits = 3) => {
+  if (!pixel) return '0rem';
+
+  const pixelFixed = Number(pixel.toFixed(fixedDigits));
+  const remFixed = (pixelFixed / rootFontSize).toFixed(fixedDigits);
+  return `${remFixed}rem`;
+};
 
 export const normalizeTextSuffixToken = (token: string) => {
   const SIZE_SUFFIX = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,7 @@ const rootFontSize = 16;
 export const convertPxToRem = (pixel: number, fixedDigits = 3) => {
   if (!pixel) return '0rem';
 
-  const pixelFixed = Number(pixel.toFixed(fixedDigits));
-  const remFixed = (pixelFixed / rootFontSize).toFixed(fixedDigits);
+  const remFixed = (pixel / rootFontSize).toFixed(fixedDigits);
   return `${remFixed}rem`;
 };
 


### PR DESCRIPTION
[Ticket](https://impulsumvc.atlassian.net/browse/COM-1136)
Example of breakpoints output:
``` 
"breakpoints": {
    "sm": "25.875rem",
    "md": "48.000rem",
    "lg": "64.000rem",
    "xl": "80.000rem",
    "2xl": "90.000rem",
    "base": "0rem",
    "xxl": "90.000rem"
  }
```